### PR TITLE
Improve license activation UX without reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,11 @@
 - Improved updater feedback by surfacing technical error details in the update dialog.
 - Improved structure creation flow with non-blocking preflight conflict warnings and a detailed partial-failure report.
 - Improved structure creation failure dialog readability with truncated path rows and expandable error details.
+- License activation now refreshes account state in-place (no full app reload), including closing activation dialogs on success.
 
 ### Fixed
 
-- No user-facing fixes yet.
+- Removed hard page reload behavior after license activation to avoid stale-state and UX loop issues.
 
 ## 0.9.1
 

--- a/src/features/auth/LicenseExpirationModal.tsx
+++ b/src/features/auth/LicenseExpirationModal.tsx
@@ -24,7 +24,7 @@ const LicenseExpirationModal: React.FC<LicenseExpirationModalProps> = ({
   onOpenChange,
 }) => {
   const [showActivateForm, setShowActivateForm] = useState(false);
-  const { activateLicense, isInitialized, license, isLicenseActive } =
+  const { activateLicense, refreshLicense, isInitialized, license, isLicenseActive } =
     useAuthContext();
 
   // Check if this is specifically an expired trial
@@ -54,7 +54,8 @@ const LicenseExpirationModal: React.FC<LicenseExpirationModalProps> = ({
   const handleLicenseActivation = async (licenseKey: string) => {
     const result = await activateLicense(licenseKey);
     if (result) {
-      window.location.reload();
+      await refreshLicense();
+      onOpenChange(false);
     } else {
       throw new Error("Invalid license key");
     }

--- a/src/pages/preferences/AccountPreferences.tsx
+++ b/src/pages/preferences/AccountPreferences.tsx
@@ -54,7 +54,8 @@ const CheckIcon = () => (
 );
 
 const AccountPreferences: React.FC = () => {
-  const { license, isLoading, error, activateLicense } = useAuthContext();
+  const { license, isLoading, error, activateLicense, refreshLicense } =
+    useAuthContext();
   const [licenseKey, setLicenseKey] = useState("");
   const [isActivating, setIsActivating] = useState(false);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -67,9 +68,10 @@ const AccountPreferences: React.FC = () => {
     try {
       const result = await activateLicense(licenseKey.trim());
       if (result) {
+        await refreshLicense();
         toast.success("License activated successfully");
-        // Refresh page to reflect updated license
-        window.location.reload();
+        setLicenseKey("");
+        setIsDialogOpen(false);
       }
     } catch (err) {
       toast.error(


### PR DESCRIPTION
## Summary
- remove hard window.location.reload calls after successful license activation
- add refreshLicense to auth context to sync license state from backend in-place
- close activation dialog and clear key field after success
- update changelog unreleased notes

## Validation
- npm run build
