### PR TITLE
fix: improve structure placeholder rendering on Intel macOS

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -22,11 +22,13 @@ export const DEFAULT_REPLACEMENT = {
   replaceInFolders: true,
 } as const;
 
-export const EXAMPLE_STRUCTURE = `folder-name
-|	sub-folder
-|	|	file.js
-|	another-sub-folder
-|	|	document.docx`;
+export const EXAMPLE_STRUCTURE = [
+  "folder-name",
+  "|    sub-folder",
+  "|    |    file.js",
+  "|    another-sub-folder",
+  "|    |    document.docx",
+].join("\r\n");
 
 export interface Feature {
   title: string;


### PR DESCRIPTION
## Summary\n- normalize the structure example placeholder to explicit CRLF line breaks\n- replace tab indentation with spaces in placeholder text\n- keep placeholder content unchanged semantically\n\n## Why\nOn an older Intel Mac, the multiline placeholder in the structure textarea rendered incorrectly (appearing flattened/broken). Using explicit line endings and space indentation improves compatibility with older WebKit rendering behavior in the Tauri webview.\n\n## Testing\n- Manual: open app with empty structure editor and verify placeholder renders on multiple lines with indentation