### PR TITLE
v0.11.11: editor focus improvements and intel placeholder fallback

### DIFF
--- a/src/components/layout/StructureSidebar.tsx
+++ b/src/components/layout/StructureSidebar.tsx
@@ -35,6 +35,8 @@ const StructureSidebar: React.FC = () => {
     if (activeStructure) {
       exitStructureEditing();
     }
+
+    window.dispatchEvent(new Event("focus-structure-editor"));
   };
 
   return (

--- a/src/features/structureEditor/components/EditorContainer.tsx
+++ b/src/features/structureEditor/components/EditorContainer.tsx
@@ -1,6 +1,7 @@
 import { APP_CONFIG, EXAMPLE_STRUCTURE } from "@/config/constants";
 import { HelpPopoverContent, StructureInput } from "@filearchitect/ui";
 import { arch, platform } from "@tauri-apps/plugin-os";
+import { useStructures } from "@/features/structures/StructureContext";
 import React from "react";
 import { useStructureEditor } from "../context/StructureEditorContext";
 import { DragOverlay } from "./DragOverlay";
@@ -14,6 +15,7 @@ export const EditorContainer: React.FC<EditorContainerProps> = React.memo(
   ({ isDragOver, isShiftPressed }) => {
     const { editorContent, setEditorContent, isLicenseActive, itemCount } =
       useStructureEditor();
+    const { activeStructure } = useStructures();
     const [showPlaceholder, setShowPlaceholder] = React.useState(true);
 
     const handleEditorChange = React.useCallback(
@@ -46,6 +48,38 @@ export const EditorContainer: React.FC<EditorContainerProps> = React.memo(
         mounted = false;
       };
     }, []);
+
+    const focusEditorTextarea = React.useCallback(() => {
+      const textarea = document.querySelector(
+        '[data-structure-editor="true"] textarea'
+      ) as HTMLTextAreaElement | null;
+      if (!textarea) return;
+
+      textarea.focus({ preventScroll: true });
+      const end = textarea.value.length;
+      textarea.setSelectionRange(end, end);
+    }, []);
+
+    React.useEffect(() => {
+      const timer = window.setTimeout(() => {
+        focusEditorTextarea();
+      }, 0);
+
+      return () => {
+        window.clearTimeout(timer);
+      };
+    }, [activeStructure?.name, focusEditorTextarea]);
+
+    React.useEffect(() => {
+      const handler = () => {
+        focusEditorTextarea();
+      };
+
+      window.addEventListener("focus-structure-editor", handler);
+      return () => {
+        window.removeEventListener("focus-structure-editor", handler);
+      };
+    }, [focusEditorTextarea]);
 
     return (
       <div className="h-full relative" data-structure-editor="true">


### PR DESCRIPTION
## Summary
- hide broken structure placeholder on Intel macOS (`darwin` + `x86_64`)
- autofocus structure editor textarea on app/editor load
- refocus textarea when switching between Quick structure and saved structures
- refocus textarea when clicking Quick structure again

## Notes
- scoped to editor UX only
- no workflow or release pipeline changes

## Validation
- behavior verified locally in app flow (quick structure, saved structure switch, quick re-select)